### PR TITLE
Split SphinxRenderer from DocutilsRenderer

### DIFF
--- a/myst_parser/sphinx_parser.py
+++ b/myst_parser/sphinx_parser.py
@@ -1,6 +1,6 @@
 from docutils import frontend, parsers
 
-from myst_parser.docutils_renderer import DocutilsRenderer
+from myst_parser.docutils_renderer import SphinxRenderer
 from myst_parser.block_tokens import Document
 
 
@@ -167,6 +167,6 @@ class MystParser(parsers.Parser):
             self.config.update(new_cfg)
         except AttributeError:
             pass
-        renderer = DocutilsRenderer(document=document)
+        renderer = SphinxRenderer(document=document)
         with renderer:
             renderer.render(Document(inputstring))

--- a/tests/sphinx_directives.json
+++ b/tests/sphinx_directives.json
@@ -109,21 +109,21 @@
         "class": "docutils.parsers.rst.directives.body.Epigraph",
         "args": [],
         "options": {},
-        "output": ""
+        "output": "<block_quote classes=\"epigraph\">"
     },
     {
         "name": "highlights",
         "class": "docutils.parsers.rst.directives.body.Highlights",
         "args": [],
         "options": {},
-        "output": ""
+        "output": "<block_quote classes=\"highlights\">"
     },
     {
         "name": "pull-quote",
         "class": "docutils.parsers.rst.directives.body.PullQuote",
         "args": [],
         "options": {},
-        "output": ""
+        "output": "<block_quote classes=\"pull-quote\">"
     },
     {
         "name": "compound",


### PR DESCRIPTION
The only addition is that the `SphinxRenderer` handles cross-references with the `pending_xref` node.