### PR TITLE
Add `BlockBreak` token (`+++`)

### DIFF
--- a/docs/using/syntax.md
+++ b/docs/using/syntax.md
@@ -40,14 +40,14 @@ For more information, also see the [CommonMark Spec](https://spec.commonmark.org
   ```
 - **LineComment**: `% this is a comment`. See {ref}`syntax/comments` for more
   information.
-
+- **BlockBreak**: `+++`. See {ref}`syntax/blockbreaks` for more information.
 
 #### CommonMark tokens
 
 - **HTMLBlock**: Any valid HTML (rendered in HTML output only)
 - **BlockCode**: indented text (4 spaces)
 - **Heading**: `# Heading` (levels 1-6)
-- **SetextHeading**: underlined header
+- **SetextHeading**: underlined header (using multiple `=` or `-`)
 - **Quote**: `> this is a quote`
 - **CodeFence**: enclosed in 3 or more backticks with an optional language name. E.g.:
   ````
@@ -419,6 +419,7 @@ This is an orphan document, not specified in any toctrees.
 ```
 
 (syntax/comments)=
+
 ### Comments
 
 You may add comments by putting the `%` character at the beginning of a line. This will
@@ -433,6 +434,26 @@ For example, this code:
 Is below, but it won't be parsed into the document.
 
 % my comment
+
+(syntax/blockbreaks)=
+
+### Block Breaks
+
+You may add a block break by putting `+++` at the beginning of a line.
+This constuct's intended use case is for mapping to cell based document formats,
+like [jupyter notebooks](https://jupyter.org/),
+to indicate a new text cell. It will not show up in the rendered text,
+but is stored in the internal document structure for use by developers.
+
+For example, this code:
+
+```
++++ some text
+```
+
+Is below, but it won't be parsed into the document.
+
++++
 
 (syntax/targets)=
 

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -192,6 +192,11 @@ class DocutilsRenderer(BaseRenderer):
     def render_thematic_break(self, token):
         self.current_node.append(nodes.transition())
 
+    def render_block_break(self, token):
+        block_break = nodes.comment(token.content, token.content)
+        block_break["classes"] += ["block_break"]
+        self.current_node.append(block_break)
+
     def render_math(self, token):
         if token.content.startswith("$$"):
             content = token.content[2:-2]

--- a/myst_parser/docutils_renderer.py
+++ b/myst_parser/docutils_renderer.py
@@ -80,7 +80,8 @@ class DocutilsRenderer(BaseRenderer):
             self.render(child)
 
     @contextmanager
-    def set_current_node(self, node, append=False):
+    def current_node_context(self, node, append: bool = False):
+        """Context manager for temporarily setting the current node."""
         if append:
             self.current_node.append(node)
         current_node = self.current_node
@@ -140,7 +141,7 @@ class DocutilsRenderer(BaseRenderer):
             return self.render_target(token.children[0])
         para = nodes.paragraph("")
         para.line = token.range[0]
-        with self.set_current_node(para, append=True):
+        with self.current_node_context(para, append=True):
             self.render_children(token)
 
     def render_line_comment(self, token):
@@ -170,18 +171,18 @@ class DocutilsRenderer(BaseRenderer):
 
     def render_strong(self, token):
         node = nodes.strong()
-        with self.set_current_node(node, append=True):
+        with self.current_node_context(node, append=True):
             self.render_children(token)
 
     def render_emphasis(self, token):
         node = nodes.emphasis()
-        with self.set_current_node(node, append=True):
+        with self.current_node_context(node, append=True):
             self.render_children(token)
 
     def render_quote(self, token):
         quote = nodes.block_quote()
         quote.line = token.range[0]
-        with self.set_current_node(quote, append=True):
+        with self.current_node_context(quote, append=True):
             self.render_children(token)
 
     def render_strikethrough(self, token):
@@ -316,7 +317,7 @@ class DocutilsRenderer(BaseRenderer):
             self.handle_cross_reference(token, destination)
         else:
             self.current_node.append(next_node)
-            with self.set_current_node(ref_node):
+            with self.current_node_context(ref_node):
                 self.render_children(token)
 
     def render_image(self, token):
@@ -352,7 +353,7 @@ class DocutilsRenderer(BaseRenderer):
         # list_node.line = token.range[0]
 
         self.current_node.append(list_node)
-        with self.set_current_node(list_node):
+        with self.current_node_context(list_node):
             self.render_children(token)
 
     def render_list_item(self, token: myst_block_tokens.ListItem):
@@ -360,7 +361,7 @@ class DocutilsRenderer(BaseRenderer):
         # TODO list item range
         # node.line = token.range[0]
         self.current_node.append(item_node)
-        with self.set_current_node(item_node):
+        with self.current_node_context(item_node):
             self.render_children(token)
 
     def render_table(self, token):
@@ -379,25 +380,25 @@ class DocutilsRenderer(BaseRenderer):
         if hasattr(token, "header"):
             thead = nodes.thead()
             tgroup += thead
-            with self.set_current_node(thead):
+            with self.current_node_context(thead):
                 self.render_table_row(token.header)
 
         tbody = nodes.tbody()
         tgroup += tbody
 
-        with self.set_current_node(tbody):
+        with self.current_node_context(tbody):
             self.render_children(token)
 
         self.current_node.append(table)
 
     def render_table_row(self, token):
         row = nodes.row()
-        with self.set_current_node(row, append=True):
+        with self.current_node_context(row, append=True):
             self.render_children(token)
 
     def render_table_cell(self, token):
         entry = nodes.entry()
-        with self.set_current_node(entry, append=True):
+        with self.current_node_context(entry, append=True):
             self.render_children(token)
 
     def render_auto_link(self, token):
@@ -668,7 +669,7 @@ class SphinxRenderer(DocutilsRenderer):
         self.current_node.append(wrap_node)
         text_node = nodes.TextElement("", "", classes=["xref", "any"])
         wrap_node.append(text_node)
-        with self.set_current_node(text_node):
+        with self.current_node_context(text_node):
             self.render_children(token)
 
     def mock_sphinx_env(self):

--- a/myst_parser/html_renderer.py
+++ b/myst_parser/html_renderer.py
@@ -43,6 +43,12 @@ class HTMLRenderer(html_renderer.HTMLRenderer):
                 '?config=TeX-MML-AM_CHTML"></script>\n'
             )
 
+    def render_document(self, token):
+        """
+        Optionally Append CDN link for MathJax to the end of <body>.
+        """
+        return super().render_document(token) + self.mathjax_src
+
     def render_code_fence(self, token):
         return self.render_block_code(token)
 
@@ -50,7 +56,10 @@ class HTMLRenderer(html_renderer.HTMLRenderer):
         raise NotImplementedError
 
     def render_line_comment(self, token):
-        raise NotImplementedError
+        return "<p>{}</p>".format(token.raw)
+
+    def render_block_break(self, token):
+        return "<p>{}</p>".format(token.raw)
 
     def render_target(self, token):
         raise NotImplementedError
@@ -62,9 +71,3 @@ class HTMLRenderer(html_renderer.HTMLRenderer):
         if token.content.startswith("$$"):
             return self.render_raw_text(token)
         return "${}$".format(self.render_raw_text(token))
-
-    def render_document(self, token):
-        """
-        Optionally Append CDN link for MathJax to the end of <body>.
-        """
-        return super().render_document(token) + self.mathjax_src

--- a/tests/test_renderers/test_docutils.py
+++ b/tests/test_renderers/test_docutils.py
@@ -253,6 +253,17 @@ def test_comment(renderer_mock):
     )
 
 
+def test_block_break(renderer_mock):
+    renderer_mock.render(tokenize(["+++ string"])[0])
+    assert renderer_mock.document.pformat() == dedent(
+        """\
+    <document source="">
+        <comment classes="block_break" xml:space="preserve">
+            string
+    """
+    )
+
+
 def test_footnote(renderer):
     renderer.render(
         Document(["[name][key]", "", '[key]: https://www.google.com "a title"', ""])

--- a/tests/test_sphinx/sourcedirs/basic/content.md
+++ b/tests/test_sphinx/sourcedirs/basic/content.md
@@ -55,6 +55,8 @@ this is a second paragraph
 
 {ref}`target`  {ref}`target2`
 
++++ a block break
+
 [name][key]
 
 [key]: https://www.google.com "a title"

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -14,6 +14,26 @@ def ast_renderer():
 @pytest.mark.parametrize(
     "name,strings",
     [
+        ("basic", ["{name}`some content`"]),
+        ("indent_2", ["  {name}`some content`"]),
+        ("indent_4", ["    {name}`some econtent`"]),
+        ("escaped", ["\\{name}`some content`"]),
+        ("inline", ["a {name}`some content`"]),
+        ("multiple", ["{name}`some content`  {name2}`other`"]),
+        ("internal_emphasis", ["{name}`*content*`"]),
+        ("external_emphasis", ["*{name}`content`*"]),
+        ("internal_math", ["{name}`some $content$`"]),
+        ("external_math", ["${name}`some content`$"]),
+    ],
+)
+def test_role(name, ast_renderer, data_regression, strings):
+    document = Document(strings)
+    data_regression.check(ast_renderer.render(document))
+
+
+@pytest.mark.parametrize(
+    "name,strings",
+    [
         ("basic", ["$a$"]),
         ("contains_special_chars", ["$a`{_*-%$"]),
         ("preceding_special_chars", ["{_*-%`$a$"]),

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -95,6 +95,25 @@ def test_comment(name, ast_renderer, data_regression, strings):
     data_regression.check(ast_renderer.render(document))
 
 
+@pytest.mark.parametrize(
+    "name,strings",
+    [
+        ("basic", ["+++"]),
+        ("indent_2", ["  +++"]),
+        ("indent_4", ["    +++"]),
+        ("escaped", [r"\+++"]),
+        ("inline", ["a +++"]),
+        ("following_content", ["+++ a"]),
+        ("following_space", ["+++   "]),
+        ("follows_list", ["- item", "+++"]),
+        ("following_content_no_space", ["+++a"]),
+    ],
+)
+def test_block_break(name, ast_renderer, data_regression, strings):
+    document = Document(strings)
+    data_regression.check(ast_renderer.render(document))
+
+
 @pytest.mark.parametrize("name,strings", [("basic", ["---", "a: b", "---"])])
 def test_front_matter(name, ast_renderer, data_regression, strings):
     document = Document(strings)

--- a/tests/test_syntax/test_ast.py
+++ b/tests/test_syntax/test_ast.py
@@ -24,6 +24,8 @@ def ast_renderer():
         ("external_emphasis", ["*{name}`content`*"]),
         ("internal_math", ["{name}`some $content$`"]),
         ("external_math", ["${name}`some content`$"]),
+        ("internal_code", ["{name}` ``some content`` `"]),
+        ("external_code", ["`` {name}`some content` ``"]),
     ],
 )
 def test_role(name, ast_renderer, data_regression, strings):

--- a/tests/test_syntax/test_ast/test_block_break_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_basic_strings0_.yml
@@ -1,9 +1,9 @@
 children:
-- content: comment
+- content: ''
   range:
   - 1
   - 1
-  raw: '% comment'
-  type: LineComment
+  raw: +++
+  type: BlockBreak
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_escaped_strings3_.yml
@@ -1,0 +1,14 @@
+children:
+- children:
+  - children:
+    - content: +
+      type: RawText
+    type: EscapeSequence
+  - content: ++
+    type: RawText
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_block_break_following_content_no_space_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_content_no_space_strings8_.yml
@@ -1,9 +1,9 @@
 children:
-- content: comment
+- content: a
   range:
   - 1
   - 1
-  raw: '% comment'
-  type: LineComment
+  raw: +++a
+  type: BlockBreak
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_following_content_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_content_strings5_.yml
@@ -1,9 +1,9 @@
 children:
-- content: comment
+- content: a
   range:
   - 1
   - 1
-  raw: '% comment'
-  type: LineComment
+  raw: +++ a
+  type: BlockBreak
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_following_space_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_following_space_strings6_.yml
@@ -1,9 +1,9 @@
 children:
-- content: comment
+- content: ''
   range:
   - 1
   - 1
-  raw: '% comment'
-  type: LineComment
+  raw: '+++   '
+  type: BlockBreak
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_follows_list_strings7_.yml
@@ -8,12 +8,12 @@ children:
       - 1
       - 1
       type: Paragraph
-    - content: comment
+    - content: ''
       range:
       - 2
       - 2
-      raw: '% comment'
-      type: LineComment
+      raw: +++
+      type: BlockBreak
     leader: '-'
     loose: false
     prepend: 2

--- a/tests/test_syntax/test_ast/test_block_break_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_2_strings1_.yml
@@ -1,9 +1,9 @@
 children:
-- content: comment
+- content: ''
   range:
   - 1
   - 1
-  raw: '% comment'
-  type: LineComment
+  raw: '  +++'
+  type: BlockBreak
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_indent_4_strings2_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - content: '+++
+
+      '
+    type: RawText
+  language: ''
+  range:
+  - 0
+  - 1
+  type: BlockCode
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_block_break_inline_strings4_.yml
@@ -1,0 +1,10 @@
+children:
+- children:
+  - content: a +++
+    type: RawText
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_comment_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_comment_indent_2_strings1_.yml
@@ -1,5 +1,9 @@
 children:
 - content: comment
+  range:
+  - 1
+  - 1
+  raw: '  % comment'
   type: LineComment
 footnotes: {}
 type: Document

--- a/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
+++ b/tests/test_syntax/test_ast/test_role_basic_strings0_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - children:
+    - content: some content
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
+++ b/tests/test_syntax/test_ast/test_role_escaped_strings3_.yml
@@ -1,0 +1,18 @@
+children:
+- children:
+  - children:
+    - content: '{'
+      type: RawText
+    type: EscapeSequence
+  - content: name}
+    type: RawText
+  - children:
+    - content: some content
+      type: RawText
+    type: InlineCode
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_code_strings11_.yml
@@ -1,0 +1,12 @@
+children:
+- children:
+  - children:
+    - content: '{name}`some content`'
+      type: RawText
+    type: InlineCode
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_emphasis_strings7_.yml
@@ -1,0 +1,15 @@
+children:
+- children:
+  - children:
+    - children:
+      - content: content
+        type: RawText
+      name: name
+      type: Role
+    type: Emphasis
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
+++ b/tests/test_syntax/test_ast/test_role_external_math_strings9_.yml
@@ -1,0 +1,10 @@
+children:
+- children:
+  - content: ${name}`some content`$
+    type: Math
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_2_strings1_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - children:
+    - content: some content
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
+++ b/tests/test_syntax/test_ast/test_role_indent_4_strings2_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - content: '{name}`some econtent`
+
+      '
+    type: RawText
+  language: ''
+  range:
+  - 0
+  - 1
+  type: BlockCode
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
+++ b/tests/test_syntax/test_ast/test_role_inline_strings4_.yml
@@ -1,0 +1,15 @@
+children:
+- children:
+  - content: 'a '
+    type: RawText
+  - children:
+    - content: some content
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_code_strings10_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - children:
+    - content: '``some content``'
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_emphasis_strings6_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - children:
+    - content: '*content*'
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
+++ b/tests/test_syntax/test_ast/test_role_internal_math_strings8_.yml
@@ -1,0 +1,13 @@
+children:
+- children:
+  - children:
+    - content: some $content$
+      type: RawText
+    name: name
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document

--- a/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
+++ b/tests/test_syntax/test_ast/test_role_multiple_strings5_.yml
@@ -1,0 +1,20 @@
+children:
+- children:
+  - children:
+    - content: some content
+      type: RawText
+    name: name
+    type: Role
+  - content: '  '
+    type: RawText
+  - children:
+    - content: other
+      type: RawText
+    name: name2
+    type: Role
+  range:
+  - 1
+  - 1
+  type: Paragraph
+footnotes: {}
+type: Document


### PR DESCRIPTION
Following from discussion in ExecutableBookProject/sphinx-notebook#12,
I have added the `BlockBreak` AST token, which parses lines beginning with `+++`.

In the docutils renderer, these lines are converted to `comment` nodes, so they won't be rendered in output text, but also with an added class, so they can be identified by potential sphinx transform extensions:

```
+++ a block break
```

goes to Markdown AST:

```yaml
type: Document
footnotes: {}
children:
- content: a block break
  range:
  - 1
  - 1
  raw: +++ a block break
  type: BlockBreak
```

and docutils AST:

```xml
<document source="">
    <comment classes="block_break" xml:space="preserve">
        a block break
```